### PR TITLE
examples: add Square and SquareRoot example

### DIFF
--- a/cmd/example_square_and_root/main.go
+++ b/cmd/example_square_and_root/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/gontract/gontract"
+)
+
+func Square(n float64) (s float64) {
+
+	gontract.Require(true, "no special precondition")
+
+	s = n * n
+
+	gontract.Ensure(s >= 0, "square of any number is non-negative")
+
+	return
+
+}
+
+func SquareRoot(n float64) (r float64) {
+
+	gontract.Require(n >= 0, "square root undefined for negative numbers")
+
+	r = math.Sqrt(n)
+
+	gontract.Ensure(Square(r) == n, "input must equal square of result")
+
+	return
+
+}
+
+func main() {
+
+	var num float64 = 1
+
+	root := SquareRoot(num)
+
+	fmt.Printf("The square root of %f is %f\n", num, root)
+
+	s := Square(num)
+
+	fmt.Printf("The square of %f is %f\n", num, s)
+
+	num = 4
+
+	root = SquareRoot(num)
+
+	fmt.Printf("The square root of %f is %f\n", num, root)
+	s = Square(num)
+
+	fmt.Printf("The square of %f is %f\n", num, s)
+
+	num = 9
+
+	root = SquareRoot(num)
+
+	fmt.Printf("The square root of %f is %f\n", num, root)
+
+	s = Square(num)
+
+	fmt.Printf("The square of %f is %f\n", num, s)
+}

--- a/cmd/example_square_and_root/main_test.go
+++ b/cmd/example_square_and_root/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gontract/gontract"
+	"github.com/stretchr/testify/assert"
+)
+
+func catch_violation(num *float64) {
+
+	var str = "foo"
+
+	gontract.CatchViolation(&str)
+	if str != "foo" {
+		*num = -1.0
+	}
+
+}
+
+func CheckSquareRoot(num float64) (ret float64) {
+
+	ret = 0
+
+	defer catch_violation(&ret)
+	ret = SquareRoot(num)
+	return
+}
+
+func CheckSquare(num float64) (ret float64) {
+
+	ret = 0
+
+	defer catch_violation(&ret)
+	ret = Square(num)
+
+	return
+
+}
+
+func TestSquare(t *testing.T) {
+
+	var num float64 = 1
+
+	s := CheckSquare(num)
+
+	//assert.True(s >= 0)
+	assert.Equal(t, s, 1.0)
+
+	num = 2
+	s = Square(num)
+
+	assert.Equal(t, s, 4.0)
+
+	num = 3
+	s = Square(num)
+
+	assert.Equal(t, s, 9.0)
+
+	return
+}
+
+func TestSquareRoot(t *testing.T) {
+
+	var num float64 = 1
+	r := CheckSquareRoot(num)
+	assert.Equal(t, r, 1.0)
+
+	num = 4
+	r = CheckSquareRoot(num)
+	assert.Equal(t, r, 2.0)
+
+	num = -1
+	r = CheckSquareRoot(num)
+	// on violation, -1 is returned:
+	assert.Equal(t, r, -1.0)
+
+	return
+}
+
+func Test_main(t *testing.T) {
+	main()
+	// trivial assert as there is nothing to test
+	assert.True(t, true)
+}


### PR DESCRIPTION
This adds an example with functions Square and Square.

This expands the condition cohesion graph by usin Square in the postcondition of SquareRoot