### PR TITLE
core: switch to using the assert package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/gontract/gontract
 
 go 1.25.1
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gitlab.com/stone.code/assert v1.1.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gitlab.com/stone.code/assert v1.1.4 h1:vYUu8lNSBjpNIgolWQxhtkA63US19p5vQ26nYrgehEs=
+gitlab.com/stone.code/assert v1.1.4/go.mod h1:vjH9OTT54rkMI9Idu4cluF4UiBLlX11MocvOlBj3YmQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/gontract.go
+++ b/gontract.go
@@ -4,7 +4,11 @@ package gontract
 // in order to allow implementing pre- and postconditions for functions in
 // the spirit of "design by contract" or "contract programming".
 
-import "fmt"
+import (
+	"fmt"
+
+	"gitlab.com/stone.code/assert"
+)
 
 type Kind int
 
@@ -66,13 +70,10 @@ func (k Kind) String() string {
 
 func Condition(predicate bool, kind Kind, msg string) (message string) {
 
-	message = "Saul Goodman"
-	if !predicate {
-		message := fmt.Sprintf("%s not satisfied (%v) - software bug!?", kind, msg)
-		if AssertionsAreEnabled() {
-			panic(message)
-		}
+	message = fmt.Sprintf("%s not satisfied (%v) - software bug!?", kind, msg)
 
+	if AssertionsAreEnabled() {
+		assert.Assert(predicate, message)
 	}
 	return
 
@@ -89,7 +90,7 @@ func Condition(predicate bool, kind Kind, msg string) (message string) {
 // For an example, see cmd/example_sqrt_success/main_test.go
 func CatchViolation(str *string) {
 	if r := recover(); r != nil {
-		*str = r.(string)
+		*str = r.(error).Error()
 	}
 }
 func PreCondition(predicate bool, msg string) {

--- a/gontract_test.go
+++ b/gontract_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 		expected  string
 	}{
 		{true, KindPre, "trivially true", "foo"},
-		{false, KindPost, "trivially false", "postcondition not satisfied (trivially false) - software bug!?"},
+		{false, KindPost, "trivially false", "assertion error: postcondition not satisfied (trivially false) - software bug!?"},
 	}
 
 	for _, c := range cases {
@@ -48,7 +48,7 @@ func TestPreCondition(t *testing.T) {
 
 	ret = checkPreCondition(false, "trivially false")
 
-	assert.Equal(t, ret, "precondition not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: precondition not satisfied (trivially false) - software bug!?")
 }
 func checkRequire(predicate bool, msg string) (ret string) {
 	ret = "foo"
@@ -64,7 +64,7 @@ func TestRequire(t *testing.T) {
 
 	ret = checkRequire(false, "trivially false")
 
-	assert.Equal(t, ret, "requirement not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: requirement not satisfied (trivially false) - software bug!?")
 }
 func checkEnsure(predicate bool, msg string) (ret string) {
 	ret = "foo"
@@ -80,7 +80,7 @@ func TestEnsure(t *testing.T) {
 
 	ret = checkEnsure(false, "trivially false")
 
-	assert.Equal(t, ret, "assurance not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: assurance not satisfied (trivially false) - software bug!?")
 }
 func checkPostCondition(predicate bool, msg string) (ret string) {
 	ret = "foo"
@@ -94,7 +94,7 @@ func TestPostCondition(t *testing.T) {
 	assert.Equal(t, ret, "foo")
 
 	ret = checkPostCondition(false, "trivially false")
-	assert.Equal(t, ret, "postcondition not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: postcondition not satisfied (trivially false) - software bug!?")
 }
 func TestEnableAssertions(t *testing.T) {
 	// default value:


### PR DESCRIPTION
This changes the condition code to use the assert package from gitlab.com/stone.code/assert instead of using panic directly.