### PR TITLE
gontract: add blame reporting to assertion messages

### DIFF
--- a/gontract.go
+++ b/gontract.go
@@ -60,11 +60,25 @@ func (k Kind) String() string {
 		return "invalid kind"
 
 	}
+
+}
+
+// Culprit function for blaming:
+func (k Kind) Culprit() string {
+	switch k {
+	case KindRequire:
+		return "caller"
+	case KindEnsure:
+		return "callee"
+	default:
+		return "unknown part"
+	}
+
 }
 
 func Condition(predicate bool, kind Kind, msg string) (message string) {
 
-	message = fmt.Sprintf("%s not satisfied (%v) - software bug!?", kind, msg)
+	message = fmt.Sprintf("%s not satisfied (%v) - software bug in %v!", kind, msg, kind.Culprit())
 
 	if AssertionsAreEnabled() {
 		assert.Assert(predicate, message)

--- a/gontract_test.go
+++ b/gontract_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 		expected  string
 	}{
 		{true, KindRequire, "trivially true", "foo"},
-		{false, KindEnsure, "trivially false", "assertion error: assurance not satisfied (trivially false) - software bug!?"},
+		{false, KindEnsure, "trivially false", "assertion error: assurance not satisfied (trivially false) - software bug in callee!"},
 	}
 
 	for _, c := range cases {
@@ -47,7 +47,7 @@ func TestRequire(t *testing.T) {
 
 	ret = checkRequire(false, "trivially false")
 
-	assert.Equal(t, ret, "assertion error: requirement not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: requirement not satisfied (trivially false) - software bug in caller!")
 }
 func checkEnsure(predicate bool, msg string) (ret string) {
 	ret = "foo"
@@ -63,7 +63,7 @@ func TestEnsure(t *testing.T) {
 
 	ret = checkEnsure(false, "trivially false")
 
-	assert.Equal(t, ret, "assertion error: assurance not satisfied (trivially false) - software bug!?")
+	assert.Equal(t, ret, "assertion error: assurance not satisfied (trivially false) - software bug in callee!")
 }
 func TestEnableAssertions(t *testing.T) {
 	// default value:


### PR DESCRIPTION
Instead of just reporting that there is a software bug when a precondition or postcondition fails, this change lets gontract blame the culprit (caller or callee).

