### PR TITLE
README:Fix typo in Require function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 | Function | Purpose | Usage |
 | :--- | :--- | :--- |
-| `Require(predicate bool, msg string)` | **Precondition**: Verifies caller-provided input. | Start of function. |
+| `Require(predicate( bool, msg string)` | **Precondition**: Verifies caller-provided input. | Start of function. |
 | `Ensure(predicate bool, msg string)` | **Postcondition**: Verifies function logic/return values. | Before return. |
 
 ---


### PR DESCRIPTION
This fixes a malformed function signature in the API reference