### PR TITLE
Makefile: add tarket lint.make and rework lint/check/test targets a bit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   build:
-    name: vet  and test
+    name: lint  and test
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -50,15 +50,7 @@ jobs:
       run: |
         echo "nothing to do"
 
-    - name:  lint the code
-      run: make check.go.lint
-      shell: bash
-
-    - name: check golang formatting
-      run: make check.go.fmt
-      shell: bash
-
-    - name:  run unit tests
+    - name:  run checks (linters and unit tests)
       run: make test
       shell: bash
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint.make: $(MK_SOURCE)
 	@$(CHECKMAKE) $(MK_SOURCE)
 
 .PHONY: fix.go.fmt
-fix.go.fmt: #␣fix␣go␣formatting (if needed)
+fix.go.fmt: # fix go formatting (if needed)
 	@ go fmt ./...
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 GOLANGCI_LINT := go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 
-.PHONY: check.go.vet
-check.go.vet:
+.PHONY: lint.go.vet
+lint.go.vet:
 	@echo "vetting go code..."
 	@go vet ./...
 
 
-.PHOHY: check.go.fmt
-check.go.fmt:
+.PHOHY: lint.go.fmt
+lint.go.fmt:
 	@echo "Checking go formatting..."
 	@if [ -n "$$(gofmt -l .)" ]; then \
 			echo "Files need formatting:"; \
@@ -25,7 +25,7 @@ fix.go.fmt: #␣fix␣go␣formatting (if needed)
 	@ go fmt ./...
 
 .PHONY: test
-test: check
+test: lint
 	@go test ./...
 
 .PHONY: golangci-lint
@@ -33,9 +33,12 @@ golangci-lint:
 	@echo "linting go code ..."
 	@$(GOLANGCI_LINT) run
 
+.PHONY: lint.go
+lint.go: lint.go.fmt lint.go.vet golangci-lint
 
-.PHONY: check.go.lint
-check.go.lint: check.go.vet golangci-lint
+
+.PHONY: lint
+lint: lint.go
 
 .PHONY: check
-check: check.go.fmt check.go.lint
+check: test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 
+MK_SOURCE := Makefile
 
+
+CHECKMAKE := go run github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
 GOLANGCI_LINT := go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 
@@ -9,7 +12,7 @@ lint.go.vet:
 	@go vet ./...
 
 
-.PHOHY: lint.go.fmt
+.PHONY: lint.go.fmt
 lint.go.fmt:
 	@echo "Checking go formatting..."
 	@if [ -n "$$(gofmt -l .)" ]; then \
@@ -20,12 +23,16 @@ lint.go.fmt:
 		echo "All files formatted correctly."; \
 	fi
 
+.PHONY: lint.make
+lint.make: $(MK_SOURCE)
+	@$(CHECKMAKE) $(MK_SOURCE)
+
 .PHONY: fix.go.fmt
 fix.go.fmt: #␣fix␣go␣formatting (if needed)
 	@ go fmt ./...
 
 .PHONY: test
-test: lint
+test: lint.go
 	@go test ./...
 
 .PHONY: golangci-lint
@@ -41,4 +48,4 @@ lint.go: lint.go.fmt lint.go.vet golangci-lint
 lint: lint.go
 
 .PHONY: check
-check: test
+check: lint test

--- a/checkmake.ini
+++ b/checkmake.ini
@@ -1,0 +1,2 @@
+[maxbodylength]
+maxBodyLength = 8


### PR DESCRIPTION
This change adds a `lint.make` target that lints the Makefile
itself with [checkmake](https://github.com/checkmake/checkmake).
    
`lint.make` fails currently so that it can not be added to the
broader `lint` target yet

In addition to the addition of the lint.make target, the lint/test/check targets
    are also reorganized a bit and some invalid characters are removed  that were added instead of space accidentally by copy and paste
