### PR TITLE
Makefile: restructure and add building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Build artifacts
+.build/

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,22 @@
+include meta.mk
 
-MK_SOURCE := Makefile
+include go.mk
+include examples.mk
 
-
-CHECKMAKE := go run github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
-GOLANGCI_LINT := go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-
-.PHONY: lint.go.vet
-lint.go.vet:
-	@echo "vetting go code..."
-	@go vet ./...
+.DEFAULT_GOAL := all
 
 
-.PHONY: lint.go.fmt
-lint.go.fmt:
-	@echo "Checking go formatting..."
-	@if [ -n "$$(gofmt -l .)" ]; then \
-			echo "Files need formatting:"; \
-				gofmt -l .; \
-				exit 1; \
-	else \
-		echo "All files formatted correctly."; \
-	fi
-
-.PHONY: lint.make
-lint.make: $(MK_SOURCE)
-	@$(CHECKMAKE) $(MK_SOURCE)
-
-.PHONY: fix.go.fmt
-fix.go.fmt: # fix go formatting (if needed)
-	@ go fmt ./...
-
-.PHONY: test
-test: lint.go
-	@go test ./...
-
-.PHONY: golangci-lint
-golangci-lint:
-	@echo "linting go code ..."
-	@$(GOLANGCI_LINT) run
-
-.PHONY: lint.go
-lint.go: lint.go.fmt lint.go.vet golangci-lint
-
+.PHONY: all
+all: build.examples
 
 .PHONY: lint
 lint: lint.go
 
+.PHONY: test
+test: test.go
+
 .PHONY: check
-check: lint test
+check: all check.build.all test run.examples.good
+
+.PHONY: clean
+clean: clean.examples

--- a/examples.mk
+++ b/examples.mk
@@ -1,0 +1,40 @@
+EXAMPLES_DIR := $(ROOT_DIR)/cmd/examples
+EXAMPLES_BUILD_DIR := $(ROOT_DIR)/.build/examples
+
+EXAMPLE_NAMES := $(sort $(notdir $(wildcard $(EXAMPLES_DIR)/*)))
+NEGATIVE_EXAMPLE_NAMES := sqrt_fail_post sqrt_fail_pre
+
+EXAMPLES_VALID := $(filter-out $(NEGATIVE_EXAMPLE_NAMES),$(EXAMPLE_NAMES))
+EXAMPLES_DEMO_BINS := $(addprefix $(EXAMPLES_BUILD_DIR)/,$(EXAMPLE_NAMES))
+
+$(EXAMPLES_BUILD_DIR):
+	@mkdir -p $@
+
+$(EXAMPLES_BUILD_DIR)/%: | $(EXAMPLES_BUILD_DIR)
+	@go build -o $@ ./cmd/examples/$*
+
+.PHONY: build.examples
+build.examples: $(EXAMPLES_DEMO_BINS)
+
+.PHONY: examples.demos
+examples.demos: build.examples
+
+.PHONY: run.examples.valid
+run.examples.valid:
+	@for example in $(EXAMPLES_VALID); do \
+		echo "running $$example..."; \
+		go run ./cmd/examples/$$example; \
+	done
+
+.PHONY: run.examples.non-negative
+run.examples.non-negative: run.examples.valid
+
+.PHONY: run.examples.success
+run.examples.success: run.examples.valid
+
+.PHONY: run.examples.good
+run.examples.good: run.examples.valid
+
+.PHONY: clean.examples
+clean.examples:
+	@rm -rf $(EXAMPLES_BUILD_DIR)

--- a/go.mk
+++ b/go.mk
@@ -1,0 +1,43 @@
+CHECKMAKE := go run github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
+GOLANGCI_LINT := go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+.PHONY: lint.go.vet
+lint.go.vet:
+	@echo "vetting go code..."
+	@go vet ./...
+
+.PHONY: lint.go.fmt
+lint.go.fmt:
+	@echo "Checking go formatting..."
+	@if [ -n "$$(gofmt -l .)" ]; then \
+			echo "Files need formatting:"; \
+				gofmt -l .; \
+				exit 1; \
+	else \
+		echo "All files formatted correctly."; \
+	fi
+
+.PHONY: lint.make
+lint.make: Makefile
+	@$(CHECKMAKE) Makefile
+
+.PHONY: fix.go.fmt
+fix.go.fmt: # fix go formatting (if needed)
+	@go fmt ./...
+
+.PHONY: test.go
+test.go: lint.go
+	@go test ./...
+
+.PHONY: check.build.all
+check.build.all: lint.go
+	@echo "building go code ..."
+	@go build ./...
+
+.PHONY: golangci-lint
+golangci-lint:
+	@echo "linting go code ..."
+	@$(GOLANGCI_LINT) run
+
+.PHONY: lint.go
+lint.go: lint.go.fmt lint.go.vet golangci-lint

--- a/meta.mk
+++ b/meta.mk
@@ -1,0 +1,2 @@
+ROOT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+GET_SELF_DIR = $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))


### PR DESCRIPTION
This refactors the Makefile into a modular include structure.

It also adds targets for:
- build checks
- building examples
- runing valid examples

It finally adds building and  running good examples to the check target.