### PR TITLE
 Makefile: broaden scope of targets lint and check and  make lint.make more verbose 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include examples.mk
 all: build.examples
 
 .PHONY: lint
-lint: lint.go
+lint: lint.go lint.make
 
 .PHONY: test
 test: test.go

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint: lint.go
 test: test.go
 
 .PHONY: check
-check: all check.build.all test run.examples.good
+check: all lint check.build.all test run.examples.good
 
 .PHONY: clean
 clean: clean.examples

--- a/go.mk
+++ b/go.mk
@@ -19,7 +19,9 @@ lint.go.fmt:
 
 .PHONY: lint.make
 lint.make: Makefile
+	@echo "checking the Makefile..."
 	@$(CHECKMAKE) Makefile
+	@echo "The Makefile is OK."
 
 .PHONY: fix.go.fmt
 fix.go.fmt: # fix go formatting (if needed)


### PR DESCRIPTION
This change:

* makes `make.lint` more verbose in an informational way
* lets `make check` additionally run the `lint` target
* ;ets `make lint` additionally run the `lint.make` target