### PR TITLE
core: add an  ifacewrap sub-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Require(..)
 
 ```
 
+## Interface wrappers
+
+For interface-based designs, keep the interface itself plain and apply
+preconditions and postconditions in a wrapper implementation around the real
+implementation.
+
+The companion package `github.com/gontract/gontract/ifacewrap` provides small
+helpers for that style. See `cmd/examples/ifacewrap_division` for a minimal
+example.
 
 
 

--- a/cmd/examples/ifacewrap_division/main.go
+++ b/cmd/examples/ifacewrap_division/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/gontract/gontract"
+	"github.com/gontract/gontract/ifacewrap"
+)
+
+const epsilon = 1e-8
+
+type Divider interface {
+	Divide(dividend, divisor float64) (quotient float64)
+}
+
+type divider struct{}
+
+func (divider) Divide(dividend, divisor float64) float64 {
+	return dividend / divisor
+}
+
+type divideInput struct {
+	dividend float64
+	divisor  float64
+}
+
+type divideOutput struct {
+	quotient float64
+}
+
+type contractDivider struct {
+	inner    Divider
+	contract ifacewrap.Contract[divideInput, divideOutput]
+}
+
+func newContractDivider(inner Divider) Divider {
+	return contractDivider{
+		inner: inner,
+		contract: ifacewrap.Contract[divideInput, divideOutput]{
+			Require: func(in divideInput) {
+				gontract.Require(in.divisor != 0, "divisor must be non-zero")
+			},
+			Ensure: func(in divideInput, out divideOutput) {
+				gontract.Ensure(floatEquals(out.quotient*in.divisor, in.dividend), "quotient calculated correctly")
+			},
+		},
+	}
+}
+
+func (d contractDivider) Divide(dividend, divisor float64) float64 {
+	out := ifacewrap.Call(
+		divideInput{dividend: dividend, divisor: divisor},
+		func() divideOutput {
+			return divideOutput{
+				quotient: d.inner.Divide(dividend, divisor),
+			}
+		},
+		d.contract,
+	)
+
+	return out.quotient
+}
+
+func floatEquals(a, b float64) bool {
+	diff := math.Abs(a - b)
+	if diff < epsilon {
+		return true
+	}
+
+	largest := math.Max(math.Abs(a), math.Abs(b))
+	return diff < largest*epsilon
+}
+
+func main() {
+	dividends := [...]float64{10.0, 4.0, 1.0, 0}
+	d := newContractDivider(divider{})
+	divisor := 2.0
+
+	for _, dividend := range dividends {
+		quotient := d.Divide(dividend, divisor)
+		fmt.Printf(" %f divided by %f  is %f\n", dividend, divisor, quotient)
+	}
+}

--- a/cmd/examples/ifacewrap_division/main_test.go
+++ b/cmd/examples/ifacewrap_division/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func catch_violation(num *float64) {
+	if r := recover(); r != nil {
+		*num = -1.0
+	}
+}
+
+func checkDivide(dividend float64, divisor float64) (ret float64) {
+	ret = 0
+	defer catch_violation(&ret)
+
+	d := newContractDivider(divider{})
+	ret = d.Divide(dividend, divisor)
+	return
+}
+
+func TestDivide(t *testing.T) {
+	cases := [...]struct {
+		dividend float64
+		divisor  float64
+		quotient float64
+	}{
+		{10.0, 2.0, 5.0},
+		{4.0, 2.0, 2.0},
+		{0.0, 2.0, 0.0},
+		{1.0, 0.0, -1.0},
+	}
+
+	for _, c := range cases {
+		quotient := checkDivide(c.dividend, c.divisor)
+		assert.Equal(t, quotient, c.quotient)
+	}
+}
+
+func Test_main(t *testing.T) {
+	var err error = nil
+	main()
+
+	assert.Equal(t, err, nil)
+}

--- a/ifacewrap/doc.go
+++ b/ifacewrap/doc.go
@@ -1,0 +1,7 @@
+// Package ifacewrap provides small helpers for writing contract-aware wrappers
+// around Go interfaces.
+//
+// The package does not attempt to generate wrappers or proxy arbitrary
+// interfaces. Instead, it keeps wrapper methods explicit and idiomatic while
+// factoring out the repetitive "require/body/ensure" control flow.
+package ifacewrap

--- a/ifacewrap/ifacewrap.go
+++ b/ifacewrap/ifacewrap.go
@@ -1,0 +1,49 @@
+package ifacewrap
+
+// Contract describes pre- and postconditions for a wrapped method call.
+//
+// In is typically a small struct that groups the method inputs.
+// Out is typically either the method result itself or a small struct that groups
+// multiple return values.
+type Contract[In any, Out any] struct {
+	Require func(In)
+	Ensure  func(In, Out)
+}
+
+// Call executes body with the given contract.
+//
+// Require, when present, runs before body. Ensure, when present, runs after body
+// and observes the final returned value.
+func Call[In any, Out any](in In, body func() Out, contract Contract[In, Out]) (out Out) {
+	if contract.Require != nil {
+		contract.Require(in)
+	}
+
+	out = body()
+
+	if contract.Ensure != nil {
+		contract.Ensure(in, out)
+	}
+
+	return
+}
+
+// Action describes pre- and postconditions for a wrapped method that does not
+// return a value.
+type Action[In any] struct {
+	Require func(In)
+	Ensure  func(In)
+}
+
+// Do executes body with the given action contract.
+func Do[In any](in In, body func(), action Action[In]) {
+	if action.Require != nil {
+		action.Require(in)
+	}
+
+	body()
+
+	if action.Ensure != nil {
+		action.Ensure(in)
+	}
+}

--- a/ifacewrap/ifacewrap_test.go
+++ b/ifacewrap/ifacewrap_test.go
@@ -1,0 +1,99 @@
+package ifacewrap
+
+import (
+	"testing"
+
+	"github.com/gontract/gontract"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCall(t *testing.T) {
+	type input struct {
+		a int
+		b int
+	}
+
+	type output struct {
+		sum int
+	}
+
+	var order []string
+
+	got := Call(
+		input{a: 2, b: 3},
+		func() output {
+			order = append(order, "body")
+			return output{sum: 5}
+		},
+		Contract[input, output]{
+			Require: func(in input) {
+				order = append(order, "require")
+				gontract.Require(in.a >= 0, "a must be non-negative")
+			},
+			Ensure: func(in input, out output) {
+				order = append(order, "ensure")
+				gontract.Ensure(out.sum == in.a+in.b, "sum must match operands")
+			},
+		},
+	)
+
+	assert.Equal(t, output{sum: 5}, got)
+	assert.Equal(t, []string{"require", "body", "ensure"}, order)
+}
+
+func TestCallViolation(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	ret := "ok"
+	defer gontract.CatchViolation(&ret)
+
+	Call(
+		input{value: -1},
+		func() output {
+			return output{value: -1}
+		},
+		Contract[input, output]{
+			Require: func(in input) {
+				gontract.Require(in.value >= 0, "value must be non-negative")
+			},
+		},
+	)
+
+	assert.Equal(t, "assertion error: requirement not satisfied (value must be non-negative) - software bug in caller!", ret)
+}
+
+func TestDo(t *testing.T) {
+	type input struct {
+		counter *int
+	}
+
+	trace := []string{}
+	counter := 0
+
+	Do(
+		input{counter: &counter},
+		func() {
+			trace = append(trace, "body")
+			counter++
+		},
+		Action[input]{
+			Require: func(in input) {
+				trace = append(trace, "require")
+				gontract.Require(in.counter != nil, "counter must not be nil")
+			},
+			Ensure: func(in input) {
+				trace = append(trace, "ensure")
+				gontract.Ensure(*in.counter == 1, "counter must be incremented")
+			},
+		},
+	)
+
+	assert.Equal(t, 1, counter)
+	assert.Equal(t, []string{"require", "body", "ensure"}, trace)
+}


### PR DESCRIPTION
This change adds a subpackage gontract/ifacewrap to gontract to facilitate creating interfaces with contracts.

Conceptually,  Golang does not support adding behavior/code to interfaces.

The ifacewrap uses generics to provide a mechanism for specifying preconditions and postconditions for the methods of an interface.

A simple example is provided in cmd/ifacewrap/ifacewrap_division/