### PR TITLE
ifacewrap: make ifcewrap self-contained to own gontract calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ preconditions and postconditions in a wrapper implementation around the real
 implementation.
 
 The companion package `github.com/gontract/gontract/ifacewrap` provides small
-helpers for that style. See `cmd/examples/ifacewrap_division` for a minimal
-example.
-
+helpers for that style. Its declarative `Requirements` and `Assurances` run
+through `gontract.Require` and `gontract.Ensure` automatically, so wrapper code
+only needs to provide predicates and messages. See
+`cmd/examples/ifacewrap_division` for a minimal example.
 
 
 

--- a/cmd/examples/ifacewrap_division/main.go
+++ b/cmd/examples/ifacewrap_division/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/gontract/gontract"
 	"github.com/gontract/gontract/ifacewrap"
 )
 
@@ -38,11 +37,21 @@ func newContractDivider(inner Divider) Divider {
 	return contractDivider{
 		inner: inner,
 		contract: ifacewrap.Contract[divideInput, divideOutput]{
-			Require: func(in divideInput) {
-				gontract.Require(in.divisor != 0, "divisor must be non-zero")
+			Requirements: []ifacewrap.Requirement[divideInput]{
+				{
+					Predicate: func(in divideInput) bool {
+						return in.divisor != 0
+					},
+					Message: "divisor must be non-zero",
+				},
 			},
-			Ensure: func(in divideInput, out divideOutput) {
-				gontract.Ensure(floatEquals(out.quotient*in.divisor, in.dividend), "quotient calculated correctly")
+			Assurances: []ifacewrap.Assurance[divideInput, divideOutput]{
+				{
+					Predicate: func(in divideInput, out divideOutput) bool {
+						return floatEquals(out.quotient*in.divisor, in.dividend)
+					},
+					Message: "quotient calculated correctly",
+				},
 			},
 		},
 	}

--- a/ifacewrap/doc.go
+++ b/ifacewrap/doc.go
@@ -3,5 +3,6 @@
 //
 // The package does not attempt to generate wrappers or proxy arbitrary
 // interfaces. Instead, it keeps wrapper methods explicit and idiomatic while
-// factoring out the repetitive "require/body/ensure" control flow.
+// factoring out the repetitive "require/body/ensure" control flow while
+// automatically dispatching declarative checks through gontract.
 package ifacewrap

--- a/ifacewrap/ifacewrap.go
+++ b/ifacewrap/ifacewrap.go
@@ -1,23 +1,55 @@
 package ifacewrap
 
+import (
+	"fmt"
+
+	"github.com/gontract/gontract"
+)
+
+// Requirement describes a precondition for a wrapped method call.
+//
+// Predicate receives the grouped method input and Message becomes the
+// gontract.Require violation text when Predicate returns false.
+type Requirement[In any] struct {
+	Predicate func(In) bool
+	Message   string
+}
+
+// Assurance describes a postcondition for a wrapped method call.
+//
+// Predicate receives the grouped method input and output, and Message becomes
+// the gontract.Ensure violation text when Predicate returns false.
+type Assurance[In any, Out any] struct {
+	Predicate func(In, Out) bool
+	Message   string
+}
+
 // Contract describes pre- and postconditions for a wrapped method call.
 //
 // In is typically a small struct that groups the method inputs.
 // Out is typically either the method result itself or a small struct that groups
 // multiple return values.
+//
+// Require and Ensure provide legacy callback hooks for callers that need custom
+// behavior. Requirements and Assurances are the preferred declarative form and
+// are automatically enforced via gontract.Require and gontract.Ensure.
 type Contract[In any, Out any] struct {
-	Require func(In)
-	Ensure  func(In, Out)
+	Require      func(In)
+	Ensure       func(In, Out)
+	Requirements []Requirement[In]
+	Assurances   []Assurance[In, Out]
 }
 
 // Call executes body with the given contract.
 //
-// Require, when present, runs before body. Ensure, when present, runs after body
-// and observes the final returned value.
+// Require and Requirements, when present, run before body. Ensure and
+// Assurances, when present, run after body and observe the final returned value.
 func Call[In any, Out any](in In, body func() Out, contract Contract[In, Out]) (out Out) {
 	if contract.Require != nil {
 		contract.Require(in)
 	}
+
+	runRequirements(in, contract.Requirements)
 
 	out = body()
 
@@ -25,14 +57,18 @@ func Call[In any, Out any](in In, body func() Out, contract Contract[In, Out]) (
 		contract.Ensure(in, out)
 	}
 
+	runAssurances(in, out, contract.Assurances)
+
 	return
 }
 
 // Action describes pre- and postconditions for a wrapped method that does not
 // return a value.
 type Action[In any] struct {
-	Require func(In)
-	Ensure  func(In)
+	Require      func(In)
+	Ensure       func(In)
+	Requirements []Requirement[In]
+	Assurances   []Requirement[In]
 }
 
 // Do executes body with the given action contract.
@@ -41,9 +77,33 @@ func Do[In any](in In, body func(), action Action[In]) {
 		action.Require(in)
 	}
 
+	runRequirements(in, action.Requirements)
+
 	body()
 
 	if action.Ensure != nil {
 		action.Ensure(in)
+	}
+
+	runRequirements(in, action.Assurances)
+}
+
+func runRequirements[In any](in In, requirements []Requirement[In]) {
+	for i, requirement := range requirements {
+		if requirement.Predicate == nil {
+			panic(fmt.Sprintf("ifacewrap: requirement %d has nil predicate", i))
+		}
+
+		gontract.Require(requirement.Predicate(in), requirement.Message)
+	}
+}
+
+func runAssurances[In any, Out any](in In, out Out, assurances []Assurance[In, Out]) {
+	for i, assurance := range assurances {
+		if assurance.Predicate == nil {
+			panic(fmt.Sprintf("ifacewrap: assurance %d has nil predicate", i))
+		}
+
+		gontract.Ensure(assurance.Predicate(in, out), assurance.Message)
 	}
 }

--- a/ifacewrap/ifacewrap_test.go
+++ b/ifacewrap/ifacewrap_test.go
@@ -26,13 +26,23 @@ func TestCall(t *testing.T) {
 			return output{sum: 5}
 		},
 		Contract[input, output]{
-			Require: func(in input) {
-				order = append(order, "require")
-				gontract.Require(in.a >= 0, "a must be non-negative")
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						order = append(order, "require")
+						return in.a >= 0
+					},
+					Message: "a must be non-negative",
+				},
 			},
-			Ensure: func(in input, out output) {
-				order = append(order, "ensure")
-				gontract.Ensure(out.sum == in.a+in.b, "sum must match operands")
+			Assurances: []Assurance[input, output]{
+				{
+					Predicate: func(in input, out output) bool {
+						order = append(order, "ensure")
+						return out.sum == in.a+in.b
+					},
+					Message: "sum must match operands",
+				},
 			},
 		},
 	)
@@ -59,8 +69,13 @@ func TestCallViolation(t *testing.T) {
 			return output{value: -1}
 		},
 		Contract[input, output]{
-			Require: func(in input) {
-				gontract.Require(in.value >= 0, "value must be non-negative")
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						return in.value >= 0
+					},
+					Message: "value must be non-negative",
+				},
 			},
 		},
 	)
@@ -83,17 +98,60 @@ func TestDo(t *testing.T) {
 			counter++
 		},
 		Action[input]{
-			Require: func(in input) {
-				trace = append(trace, "require")
-				gontract.Require(in.counter != nil, "counter must not be nil")
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						trace = append(trace, "require")
+						return in.counter != nil
+					},
+					Message: "counter must not be nil",
+				},
 			},
-			Ensure: func(in input) {
-				trace = append(trace, "ensure")
-				gontract.Ensure(*in.counter == 1, "counter must be incremented")
+			Assurances: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						trace = append(trace, "ensure")
+						return *in.counter == 1
+					},
+					Message: "counter must be incremented",
+				},
 			},
 		},
 	)
 
 	assert.Equal(t, 1, counter)
 	assert.Equal(t, []string{"require", "body", "ensure"}, trace)
+}
+
+func TestCallLegacyHooks(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	var order []string
+
+	got := Call(
+		input{value: 3},
+		func() output {
+			order = append(order, "body")
+			return output{value: 3}
+		},
+		Contract[input, output]{
+			Require: func(in input) {
+				order = append(order, "require")
+				gontract.Require(in.value > 0, "value must be positive")
+			},
+			Ensure: func(in input, out output) {
+				order = append(order, "ensure")
+				gontract.Ensure(out.value == in.value, "value must round-trip")
+			},
+		},
+	)
+
+	assert.Equal(t, output{value: 3}, got)
+	assert.Equal(t, []string{"require", "body", "ensure"}, order)
 }


### PR DESCRIPTION
users of ifacewrap also needed to import gontract/gontract and pass gontract.Require and gontract.Ensure calls to ifacewrap.

This change mofifies ifacewrap so that it now owns the gontract calls. This way, users of ifacewrap can declare predicates and messages without importing and calling gontract directly.

Users of ifacewrap now only need to import ifacewrap, no longer gontract.