### PR TITLE
funcwrap: add a funcwrap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ through `gontract.Require` and `gontract.Ensure` automatically, so wrapper code
 only needs to provide predicates and messages. See
 `cmd/examples/ifacewrap_division` for a minimal example.
 
+# function wrappers (funcwrap)
+
+In addition to ifacewrap, the companion package `github.com/gontract/gontract/funcwrap`
+provides helpers for defining a function along with its contract.
+
+
 
 
 

--- a/cmd/examples/funcwrap_division/main.go
+++ b/cmd/examples/funcwrap_division/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/gontract/gontract/funcwrap"
+)
+
+type divideInput struct {
+	dividend float64
+	divisor  float64
+}
+type divideOutput struct {
+	quotient float64
+}
+
+const epsilon = 1e-8
+
+func floatEquals(a, b float64) bool {
+	diff := math.Abs(a - b)
+	if diff < epsilon {
+		return true
+	}
+
+	largest := math.Max(math.Abs(a), math.Abs(b))
+	return diff < largest*epsilon
+}
+
+func Divide(dividend float64, divisor float64) (quotient float64) {
+	quotient = funcwrap.Call(
+		divideInput{dividend: dividend, divisor: divisor},
+		func() divideOutput {
+			return divideOutput{quotient: dividend / divisor}
+		},
+		funcwrap.Contract[divideInput, divideOutput]{
+			Requirements: []funcwrap.Requirement[divideInput]{
+				{
+					Predicate: func(in divideInput) bool { return in.divisor != 0 },
+					Message:   "divisor must be non-zero",
+				},
+			},
+			Assurances: []funcwrap.Assurance[divideInput, divideOutput]{
+				{
+					Predicate: func(in divideInput, out divideOutput) bool {
+						return floatEquals(out.quotient*in.divisor, in.dividend)
+					},
+					Message: "quotient calculated correctly",
+				},
+			},
+		},
+	).quotient
+
+	return
+}
+
+func main() {
+	dividends := [...]float64{10.0, 4.0, 1.0, 0}
+	var divisor = 2.0
+
+	for _, dividend := range dividends {
+
+		quotient := Divide(dividend, divisor)
+		fmt.Printf(" %f divided by %f  is %f\n", dividend, divisor, quotient)
+	}
+}

--- a/cmd/examples/funcwrap_division/main_test.go
+++ b/cmd/examples/funcwrap_division/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func catch_violation(num *float64) {
+
+	if r := recover(); r != nil {
+		*num = -1.0
+	}
+}
+
+func checkDivide(dividend float64, divisor float64) (ret float64) {
+
+	ret = 0
+	defer catch_violation(&ret)
+
+	ret = Divide(dividend, divisor)
+	return
+
+}
+
+func TestDivide(t *testing.T) {
+
+	cases := [...]struct {
+		dividend float64
+		divisor  float64
+		quotient float64
+	}{
+		{10.0, 2.0, 5.0},
+		{4.0, 2.0, 2.0},
+		{0.0, 2.0, 0.0},
+		{1.0, 0.0, -1.0},
+	}
+	for _, c := range cases {
+		quotient := checkDivide(c.dividend, c.divisor)
+		assert.Equal(t, quotient, c.quotient)
+	}
+}
+
+func Test_main(t *testing.T) {
+	var err error = nil
+	main()
+
+	// trivial condition as main has no result
+	assert.Equal(t, err, nil)
+
+}

--- a/funcwrap/doc.go
+++ b/funcwrap/doc.go
@@ -1,0 +1,15 @@
+// Package funcwrap provides small helpers for writing contract-aware wrappers
+// around individual Go functions.
+//
+// The package keeps wrappers explicit and idiomatic while factoring out the
+// repetitive "require/body/ensure" control flow and automatically dispatching
+// declarative checks through gontract.
+//
+// Use Call for functions that return a value and Do for functions that do not.
+// A typical wrapper groups the function inputs into a small struct so that
+// preconditions and postconditions can inspect the full call state.
+//
+// Requirements and Assurances are the preferred API. The lower-level
+// Require and Ensure callback hooks remain available for contracts that need
+// imperative logic instead of a single predicate/message pair.
+package funcwrap

--- a/funcwrap/funcwrap.go
+++ b/funcwrap/funcwrap.go
@@ -1,0 +1,109 @@
+package funcwrap
+
+import (
+	"fmt"
+
+	"github.com/gontract/gontract"
+)
+
+// Requirement describes a precondition for a wrapped function call.
+//
+// Predicate receives the grouped function input and Message becomes the
+// gontract.Require violation text when Predicate returns false.
+type Requirement[In any] struct {
+	Predicate func(In) bool
+	Message   string
+}
+
+// Assurance describes a postcondition for a wrapped function call.
+//
+// Predicate receives the grouped function input and output, and Message becomes
+// the gontract.Ensure violation text when Predicate returns false.
+type Assurance[In any, Out any] struct {
+	Predicate func(In, Out) bool
+	Message   string
+}
+
+// Contract describes pre- and postconditions for a wrapped function call.
+//
+// In is typically a small struct that groups the function inputs.
+// Out is typically either the function result itself or a small struct that
+// groups multiple return values.
+//
+// Require and Ensure provide legacy callback hooks for callers that need custom
+// behavior. Requirements and Assurances are the preferred declarative form and
+// are automatically enforced via gontract.Require and gontract.Ensure.
+type Contract[In any, Out any] struct {
+	Require      func(In)
+	Ensure       func(In, Out)
+	Requirements []Requirement[In]
+	Assurances   []Assurance[In, Out]
+}
+
+// Call executes body with the given contract.
+//
+// Require and Requirements, when present, run before body. Ensure and
+// Assurances, when present, run after body and observe the final returned value.
+func Call[In any, Out any](in In, body func() Out, contract Contract[In, Out]) (out Out) {
+	if contract.Require != nil {
+		contract.Require(in)
+	}
+
+	runRequirements(in, contract.Requirements)
+
+	out = body()
+
+	if contract.Ensure != nil {
+		contract.Ensure(in, out)
+	}
+
+	runAssurances(in, out, contract.Assurances)
+
+	return
+}
+
+// Action describes pre- and postconditions for a wrapped function that does not
+// return a value.
+type Action[In any] struct {
+	Require      func(In)
+	Ensure       func(In)
+	Requirements []Requirement[In]
+	Assurances   []Requirement[In]
+}
+
+// Do executes body with the given action contract.
+func Do[In any](in In, body func(), action Action[In]) {
+	if action.Require != nil {
+		action.Require(in)
+	}
+
+	runRequirements(in, action.Requirements)
+
+	body()
+
+	if action.Ensure != nil {
+		action.Ensure(in)
+	}
+
+	runRequirements(in, action.Assurances)
+}
+
+func runRequirements[In any](in In, requirements []Requirement[In]) {
+	for i, requirement := range requirements {
+		if requirement.Predicate == nil {
+			panic(fmt.Sprintf("funcwrap: requirement %d has nil predicate", i))
+		}
+
+		gontract.Require(requirement.Predicate(in), requirement.Message)
+	}
+}
+
+func runAssurances[In any, Out any](in In, out Out, assurances []Assurance[In, Out]) {
+	for i, assurance := range assurances {
+		if assurance.Predicate == nil {
+			panic(fmt.Sprintf("funcwrap: assurance %d has nil predicate", i))
+		}
+
+		gontract.Ensure(assurance.Predicate(in, out), assurance.Message)
+	}
+}

--- a/funcwrap/funcwrap_test.go
+++ b/funcwrap/funcwrap_test.go
@@ -1,0 +1,205 @@
+package funcwrap
+
+import (
+	"testing"
+
+	"github.com/gontract/gontract"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCall(t *testing.T) {
+	type input struct {
+		a int
+		b int
+	}
+
+	type output struct {
+		sum int
+	}
+
+	var order []string
+
+	got := Call(
+		input{a: 2, b: 3},
+		func() output {
+			order = append(order, "body")
+			return output{sum: 5}
+		},
+		Contract[input, output]{
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						order = append(order, "require")
+						return in.a >= 0
+					},
+					Message: "a must be non-negative",
+				},
+			},
+			Assurances: []Assurance[input, output]{
+				{
+					Predicate: func(in input, out output) bool {
+						order = append(order, "ensure")
+						return out.sum == in.a+in.b
+					},
+					Message: "sum must match operands",
+				},
+			},
+		},
+	)
+
+	assert.Equal(t, output{sum: 5}, got)
+	assert.Equal(t, []string{"require", "body", "ensure"}, order)
+}
+
+func TestCallViolation(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	ret := "ok"
+	defer gontract.CatchViolation(&ret)
+
+	Call(
+		input{value: -1},
+		func() output {
+			return output{value: -1}
+		},
+		Contract[input, output]{
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						return in.value >= 0
+					},
+					Message: "value must be non-negative",
+				},
+			},
+		},
+	)
+
+	assert.Equal(t, "assertion error: requirement not satisfied (value must be non-negative) - software bug in caller!", ret)
+}
+
+func TestDo(t *testing.T) {
+	type input struct {
+		counter *int
+	}
+
+	trace := []string{}
+	counter := 0
+
+	Do(
+		input{counter: &counter},
+		func() {
+			trace = append(trace, "body")
+			counter++
+		},
+		Action[input]{
+			Requirements: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						trace = append(trace, "require")
+						return in.counter != nil
+					},
+					Message: "counter must not be nil",
+				},
+			},
+			Assurances: []Requirement[input]{
+				{
+					Predicate: func(in input) bool {
+						trace = append(trace, "ensure")
+						return *in.counter == 1
+					},
+					Message: "counter must be incremented",
+				},
+			},
+		},
+	)
+
+	assert.Equal(t, 1, counter)
+	assert.Equal(t, []string{"require", "body", "ensure"}, trace)
+}
+
+func TestCallLegacyHooks(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	var order []string
+
+	got := Call(
+		input{value: 3},
+		func() output {
+			order = append(order, "body")
+			return output{value: 3}
+		},
+		Contract[input, output]{
+			Require: func(in input) {
+				order = append(order, "require")
+				gontract.Require(in.value > 0, "value must be positive")
+			},
+			Ensure: func(in input, out output) {
+				order = append(order, "ensure")
+				gontract.Ensure(out.value == in.value, "value must round-trip")
+			},
+		},
+	)
+
+	assert.Equal(t, output{value: 3}, got)
+	assert.Equal(t, []string{"require", "body", "ensure"}, order)
+}
+
+func TestCallNilRequirementPredicatePanics(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	requirementPanic := func() {
+		Call(
+			input{value: 1},
+			func() output { return output{value: 1} },
+			Contract[input, output]{
+				Requirements: []Requirement[input]{
+					{},
+				},
+			},
+		)
+	}
+
+	assert.PanicsWithValue(t, "funcwrap: requirement 0 has nil predicate", requirementPanic)
+}
+
+func TestCallNilAssurancePredicatePanics(t *testing.T) {
+	type input struct {
+		value int
+	}
+
+	type output struct {
+		value int
+	}
+
+	assurancePanic := func() {
+		Call(
+			input{value: 1},
+			func() output { return output{value: 1} },
+			Contract[input, output]{
+				Assurances: []Assurance[input, output]{
+					{},
+				},
+			},
+		)
+	}
+
+	assert.PanicsWithValue(t, "funcwrap: assurance 0 has nil predicate", assurancePanic)
+}


### PR DESCRIPTION
Package to wrap individual functions with gontract-style contracts as opposed to ifacewrap wrapping entire interfaces.