### PR TITLE
use manc.FloatEquals

### DIFF
--- a/cmd/examples/division/main.go
+++ b/cmd/examples/division/main.go
@@ -4,26 +4,10 @@ package main
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/gontract/gontract"
+	"github.com/obnoxxx/manc"
 )
-
-const epsilon = 1e-8
-
-// floatEquals():
-// function to use instead of == for comparing floats.
-// This takes rounding errors into account.
-func floatEquals(a, b float64) bool {
-	// absolute comparison:
-	diff := math.Abs(a - b)
-	if diff < epsilon {
-		return true
-	}
-	// additional relative comparison to avoid false negatives
-	largest := math.Max(math.Abs(a), math.Abs(b))
-	return diff < largest*epsilon
-}
 
 func Divide(dividend float64, divisor float64) (quotient float64) {
 
@@ -31,7 +15,7 @@ func Divide(dividend float64, divisor float64) (quotient float64) {
 	gontract.Require(divisor != 0, "divisor must be non-zero")
 	// postcondition:
 	defer func() {
-		gontract.Ensure(floatEquals(quotient*divisor, dividend), "quotient calculated correctly")
+		gontract.Ensure(manc.FloatEquals(quotient*divisor, dividend), "quotient calculated correctly")
 	}()
 
 	quotient = dividend / divisor

--- a/cmd/examples/funcwrap_division/main.go
+++ b/cmd/examples/funcwrap_division/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/gontract/gontract/funcwrap"
+	"github.com/obnoxxx/manc"
 )
 
 type divideInput struct {
@@ -13,18 +13,6 @@ type divideInput struct {
 }
 type divideOutput struct {
 	quotient float64
-}
-
-const epsilon = 1e-8
-
-func floatEquals(a, b float64) bool {
-	diff := math.Abs(a - b)
-	if diff < epsilon {
-		return true
-	}
-
-	largest := math.Max(math.Abs(a), math.Abs(b))
-	return diff < largest*epsilon
 }
 
 func Divide(dividend float64, divisor float64) (quotient float64) {
@@ -43,7 +31,7 @@ func Divide(dividend float64, divisor float64) (quotient float64) {
 			Assurances: []funcwrap.Assurance[divideInput, divideOutput]{
 				{
 					Predicate: func(in divideInput, out divideOutput) bool {
-						return floatEquals(out.quotient*in.divisor, in.dividend)
+						return manc.FloatEquals(out.quotient*in.divisor, in.dividend)
 					},
 					Message: "quotient calculated correctly",
 				},

--- a/cmd/examples/ifacewrap_division/main.go
+++ b/cmd/examples/ifacewrap_division/main.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/gontract/gontract/ifacewrap"
+	"github.com/obnoxxx/manc"
 )
-
-const epsilon = 1e-8
 
 type Divider interface {
 	Divide(dividend, divisor float64) (quotient float64)
@@ -48,7 +46,7 @@ func newContractDivider(inner Divider) Divider {
 			Assurances: []ifacewrap.Assurance[divideInput, divideOutput]{
 				{
 					Predicate: func(in divideInput, out divideOutput) bool {
-						return floatEquals(out.quotient*in.divisor, in.dividend)
+						return manc.FloatEquals(out.quotient*in.divisor, in.dividend)
 					},
 					Message: "quotient calculated correctly",
 				},
@@ -69,16 +67,6 @@ func (d contractDivider) Divide(dividend, divisor float64) float64 {
 	)
 
 	return out.quotient
-}
-
-func floatEquals(a, b float64) bool {
-	diff := math.Abs(a - b)
-	if diff < epsilon {
-		return true
-	}
-
-	largest := math.Max(math.Abs(a), math.Abs(b))
-	return diff < largest*epsilon
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gontract/gontract
 go 1.26
 
 require (
+	github.com/obnoxxx/manc v0.1.0
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/stone.code/assert v1.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/obnoxxx/manc v0.1.0 h1:eY3wEHTHCyeAoEP6X1VpvFHY6uUiG9SerPHttBQeONE=
+github.com/obnoxxx/manc v0.1.0/go.mod h1:diV9MnwFpgCkh+pN08izkq2kGOSW/924d3po0CiROnE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
This changes division examples from implementing floatEquals to using manc.FloatEquals from github.com/obnoxxx/manc.

Assisted-by: GitHub copilot